### PR TITLE
PowerSupply issue fixed

### DIFF
--- a/FINAL_EXPERIMENTS/COMPLETE/Norton Theorem/Function/Issues.md
+++ b/FINAL_EXPERIMENTS/COMPLETE/Norton Theorem/Function/Issues.md
@@ -1,0 +1,6 @@
+# Issues Fixed
+
+1. No need to turn on the powersupply before connecting the wires.
+1. The three cases are given order-wise in inst. tab, but any case can be performed in any order.
+1. Improved case detection in add function. (issue arrised due to above changes).
+1. Only the correct procedure can be followed in the experiment. (wrong buttons are either deactivated or show warning).

--- a/FINAL_EXPERIMENTS/COMPLETE/Norton Theorem/Function/function.js
+++ b/FINAL_EXPERIMENTS/COMPLETE/Norton Theorem/Function/function.js
@@ -78,6 +78,7 @@ var flags1 = 0
 var flags1_2 = 0
 var flags4 = 0
 var flags5 = 0
+var flagADD = 0
 
 window.onload = function setSize() {
     document.body.style.zoom = "89%"
@@ -261,6 +262,7 @@ check.onclick = function callCheck() {
             window.alert("Multimeter connected")
             case_checks.push(1)
             caseVal = 1;
+            add.disabled = false
         }
         else if ((i == 1) && (checkcon(valList[i])) == 4) {
             window.alert("Ammeter connected, please turn on the power supply")
@@ -289,9 +291,9 @@ check.onclick = function callCheck() {
 
     iter.push(caseVal)
 
-    if ((iter.indexOf(1) >= 0) && (iter.indexOf(2) >= 0) && (iter.indexOf(3) >= 0)) {
-        add.disabled = false
-    }
+    // if ((iter.indexOf(1) >= 0) && (iter.indexOf(2) >= 0) && (iter.indexOf(3) >= 0)) {
+    //     add.disabled = false
+    // }
 
     updateAmmeters(caseVal)
 }
@@ -299,10 +301,13 @@ check.onclick = function callCheck() {
 on_pow.onclick = function toggle() {
     if (pow_state == 0) {
         document.getElementById("power").src = "../Assets/PowerSupplyOn.png"
-        variacSlider.disabled = false
         updateAmmeters()
         pow_state = 1;
-        add.disabled=false
+        add.disabled = false
+
+        if (flagADD == 0) {
+            variacSlider.disabled = false
+        }
     }
     else if (pow_state == 1) {
         document.getElementById("power").src = "../Assets/PowerSupplyOff.png"
@@ -314,11 +319,14 @@ on_pow.onclick = function toggle() {
 
 add.onclick = function AddToTable() {
 
-    variacSlider.disabled = true;
     document.getElementById("power").src = "../Assets/PowerSupplyOff.png"
-    variacSlider.disabled = true
     pow_state = 0;
     P_A.style.transform = "rotate(0deg)"
+
+    variacSlider.disabled = true
+    if (caseVal != 1) {
+        flagADD = 1
+    }
 
     calculate.disabled = false
 
@@ -332,7 +340,7 @@ add.onclick = function AddToTable() {
     let tabRl
 
 
-    if ((case_checks.indexOf(1) != -1) && (case_checks.indexOf(2) != -1) && (case_checks.indexOf(3) != -1) && (case_checks.length > 3)) {
+    if ((vtable.rows[1].cells[2].innerHTML != '-') && (vtable.rows[1].cells[3].innerHTML != '-') && (vtable.rows[1].cells[4].innerHTML != '-')) {
         row = vtable.insertRow(obs + 1);
 
         SNo = row.insertCell(0);
@@ -372,7 +380,7 @@ add.onclick = function AddToTable() {
     tabRl.innerHTML = document.getElementById("Rls").value;
 
     calculate.disabled = false
-    add.disabled=true
+    add.disabled = true
 }
 
 calculate.onclick = function doCalc() {

--- a/FINAL_EXPERIMENTS/COMPLETE/Norton Theorem/Webpages/index.html
+++ b/FINAL_EXPERIMENTS/COMPLETE/Norton Theorem/Webpages/index.html
@@ -34,9 +34,9 @@
                     <li id="s2">Make connections and check them by clicking 'CHECK' button, and then record observations by clicking on 'ADD'</li>
                     <ul>
                         <li>To measure R_th, short circuit the terminals for power-supply, and connect the circuit to
-                            multimeter, and check connections. Then destroy the connections (Click on 'RESET' button to reset connections) 7->8, 3->9, 4->11</li>
+                            multimeter, and check connections. 7->8, 3->9, 4->11</li>
                            
-                        <li>Now measure I_sc connect cirucit to power-supply, connect the red and blue nodes of the main curcit to the ammeter. (Click on 'RESET' button to reset connections) 5->7, 6->8, 1->9, 2->11</li>
+                        <li>Now measure I_sc connect cirucit to power-supply, connect the red and blue nodes of the main curcit to the ammeter. 5->7, 6->8, 1->9, 2->11</li>
                             
                         <li>To measure load current connect the blue nodes (lower right hand side of screen) to each other, and connect ammeter in series to R_load. 5->7, 6->8, 11->12, 1->9, 10->2</li>
                             


### PR DESCRIPTION
No need to turn on PowerSupply before connecting wires. The same issue will be fixed in other experiments once this experiment is approved.